### PR TITLE
Feat/2: add routing, pagination

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "react-relay": "^14.1.0",
+    "react-router-dom": "^6.3.0",
     "react-scripts": "5.0.1",
     "relay-runtime": "^14.1.0",
     "styled-components": "^5.3.5",

--- a/src/components/Result.tsx
+++ b/src/components/Result.tsx
@@ -1,0 +1,69 @@
+import React, { Fragment, useState, useEffect } from 'react';
+import styled from 'styled-components';
+import { useLazyLoadQuery } from 'react-relay';
+import { graphql } from 'babel-plugin-relay/macro';
+
+function Result({
+  refetch,
+  queryArgs,
+  setCursor,
+}: {
+  refetch: any;
+  queryArgs: any;
+  setCursor: any;
+}) {
+  const [searchedLists, setSearchedLists] = useState<any[]>([]);
+  const data: any = useLazyLoadQuery(
+    graphql`
+      query ResultQuery($endCursor: String) {
+        search(query: "react", first: 5, after: $endCursor, type: REPOSITORY) {
+          repositoryCount
+          edges {
+            node {
+              ... on Repository {
+                id
+                name
+                description
+                stargazerCount
+              }
+            }
+            cursor
+          }
+          pageInfo {
+            endCursor
+            hasNextPage
+          }
+        }
+      }
+    `,
+    queryArgs.variables,
+    queryArgs.options
+  );
+
+  useEffect(() => {
+    setCursor(data.search.pageInfo.endCursor);
+    setSearchedLists((prev) => prev.concat(...data.search.edges));
+  }, [queryArgs.options.fetchKey]);
+
+  return (
+    <div>
+      <div>Total result: {data.search.repositoryCount}</div>
+      {searchedLists.map((item: any) => (
+        <Fragment key={item?.node?.id}>
+          <RepositoryElementContainer>
+            <div>{item?.node?.name}</div>
+            <div>{item?.node?.description}</div>
+            <div>{item?.node?.stargazerCount}</div>
+          </RepositoryElementContainer>
+        </Fragment>
+      ))}
+      {data.search.pageInfo.hasNextPage ? <button onClick={() => refetch()}>더보기</button> : null}
+    </div>
+  );
+}
+
+export default Result;
+
+const RepositoryElementContainer = styled.div`
+  padding: 20px;
+`;

--- a/src/components/Search.tsx
+++ b/src/components/Search.tsx
@@ -1,0 +1,38 @@
+import React, { useState } from 'react';
+import { useNavigate } from 'react-router-dom';
+
+function Search() {
+  const [searchedWord, setSearchedWord] = useState<string>('');
+
+  const navigate = useNavigate();
+
+  const handleChange = (e: React.BaseSyntheticEvent) => {
+    e.persist();
+
+    const word = e.currentTarget.value;
+    setSearchedWord(word);
+  };
+
+  const handleSubmit = (e: React.BaseSyntheticEvent) => {
+    e.preventDefault();
+    navigate(`/result/${searchedWord}`);
+  };
+
+  return (
+    <>
+      <form onSubmit={handleSubmit}>
+        <div>this is Search component</div>
+        <input
+          id="searchedWord"
+          type="text"
+          onChange={handleChange}
+          autoComplete="off"
+          autoCapitalize="off"
+        />
+        <button>to result component</button>
+      </form>
+    </>
+  );
+}
+
+export default Search;

--- a/src/components/__generated__/ResultQuery.graphql.ts
+++ b/src/components/__generated__/ResultQuery.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<198d938554e160a9b6692eee167d6bfc>>
+ * @generated SignedSource<<8574e4a9f2c027fe7656442754ff5384>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -9,8 +9,10 @@
 // @ts-nocheck
 
 import { ConcreteRequest, Query } from 'relay-runtime';
-export type AppRepositoryListQuery$variables = {};
-export type AppRepositoryListQuery$data = {
+export type ResultQuery$variables = {
+  endCursor?: string | null;
+};
+export type ResultQuery$data = {
   readonly search: {
     readonly edges: ReadonlyArray<{
       readonly cursor: string;
@@ -28,13 +30,25 @@ export type AppRepositoryListQuery$data = {
     readonly repositoryCount: number;
   };
 };
-export type AppRepositoryListQuery = {
-  response: AppRepositoryListQuery$data;
-  variables: AppRepositoryListQuery$variables;
+export type ResultQuery = {
+  response: ResultQuery$data;
+  variables: ResultQuery$variables;
 };
 
 const node: ConcreteRequest = (function(){
 var v0 = [
+  {
+    "defaultValue": null,
+    "kind": "LocalArgument",
+    "name": "endCursor"
+  }
+],
+v1 = [
+  {
+    "kind": "Variable",
+    "name": "after",
+    "variableName": "endCursor"
+  },
   {
     "kind": "Literal",
     "name": "first",
@@ -51,24 +65,24 @@ var v0 = [
     "value": "REPOSITORY"
   }
 ],
-v1 = {
+v2 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "repositoryCount",
   "storageKey": null
 },
-v2 = {
+v3 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "id",
   "storageKey": null
 },
-v3 = {
+v4 = {
   "kind": "InlineFragment",
   "selections": [
-    (v2/*: any*/),
+    (v3/*: any*/),
     {
       "alias": null,
       "args": null,
@@ -94,14 +108,14 @@ v3 = {
   "type": "Repository",
   "abstractKey": null
 },
-v4 = {
+v5 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "cursor",
   "storageKey": null
 },
-v5 = {
+v6 = {
   "alias": null,
   "args": null,
   "concreteType": "PageInfo",
@@ -128,20 +142,20 @@ v5 = {
 };
 return {
   "fragment": {
-    "argumentDefinitions": [],
+    "argumentDefinitions": (v0/*: any*/),
     "kind": "Fragment",
     "metadata": null,
-    "name": "AppRepositoryListQuery",
+    "name": "ResultQuery",
     "selections": [
       {
         "alias": null,
-        "args": (v0/*: any*/),
+        "args": (v1/*: any*/),
         "concreteType": "SearchResultItemConnection",
         "kind": "LinkedField",
         "name": "search",
         "plural": false,
         "selections": [
-          (v1/*: any*/),
+          (v2/*: any*/),
           {
             "alias": null,
             "args": null,
@@ -158,17 +172,17 @@ return {
                 "name": "node",
                 "plural": false,
                 "selections": [
-                  (v3/*: any*/)
+                  (v4/*: any*/)
                 ],
                 "storageKey": null
               },
-              (v4/*: any*/)
+              (v5/*: any*/)
             ],
             "storageKey": null
           },
-          (v5/*: any*/)
+          (v6/*: any*/)
         ],
-        "storageKey": "search(first:5,query:\"react\",type:\"REPOSITORY\")"
+        "storageKey": null
       }
     ],
     "type": "Query",
@@ -176,19 +190,19 @@ return {
   },
   "kind": "Request",
   "operation": {
-    "argumentDefinitions": [],
+    "argumentDefinitions": (v0/*: any*/),
     "kind": "Operation",
-    "name": "AppRepositoryListQuery",
+    "name": "ResultQuery",
     "selections": [
       {
         "alias": null,
-        "args": (v0/*: any*/),
+        "args": (v1/*: any*/),
         "concreteType": "SearchResultItemConnection",
         "kind": "LinkedField",
         "name": "search",
         "plural": false,
         "selections": [
-          (v1/*: any*/),
+          (v2/*: any*/),
           {
             "alias": null,
             "args": null,
@@ -212,11 +226,11 @@ return {
                     "name": "__typename",
                     "storageKey": null
                   },
-                  (v3/*: any*/),
+                  (v4/*: any*/),
                   {
                     "kind": "InlineFragment",
                     "selections": [
-                      (v2/*: any*/)
+                      (v3/*: any*/)
                     ],
                     "type": "Node",
                     "abstractKey": "__isNode"
@@ -224,27 +238,27 @@ return {
                 ],
                 "storageKey": null
               },
-              (v4/*: any*/)
+              (v5/*: any*/)
             ],
             "storageKey": null
           },
-          (v5/*: any*/)
+          (v6/*: any*/)
         ],
-        "storageKey": "search(first:5,query:\"react\",type:\"REPOSITORY\")"
+        "storageKey": null
       }
     ]
   },
   "params": {
-    "cacheID": "5ae860b0e8fc4aa8734bc2ad4b6198d6",
+    "cacheID": "8f9312fbad090ace4de61e44127c5fdb",
     "id": null,
     "metadata": {},
-    "name": "AppRepositoryListQuery",
+    "name": "ResultQuery",
     "operationKind": "query",
-    "text": "query AppRepositoryListQuery {\n  search(query: \"react\", first: 5, type: REPOSITORY) {\n    repositoryCount\n    edges {\n      node {\n        __typename\n        ... on Repository {\n          id\n          name\n          description\n          stargazerCount\n        }\n        ... on Node {\n          __isNode: __typename\n          id\n        }\n      }\n      cursor\n    }\n    pageInfo {\n      endCursor\n      hasNextPage\n    }\n  }\n}\n"
+    "text": "query ResultQuery(\n  $endCursor: String\n) {\n  search(query: \"react\", first: 5, after: $endCursor, type: REPOSITORY) {\n    repositoryCount\n    edges {\n      node {\n        __typename\n        ... on Repository {\n          id\n          name\n          description\n          stargazerCount\n        }\n        ... on Node {\n          __isNode: __typename\n          id\n        }\n      }\n      cursor\n    }\n    pageInfo {\n      endCursor\n      hasNextPage\n    }\n  }\n}\n"
   }
 };
 })();
 
-(node as any).hash = "e4b0c37a1662d5b21d016f626a08cb62";
+(node as any).hash = "a2e457b9d6082f84c02a32f5c8053888";
 
 export default node;

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -1,10 +1,11 @@
 import React from 'react';
 import ReactDOM from 'react-dom/client';
 import App from './App';
+import { BrowserRouter as Router } from 'react-router-dom';
 
 const root = ReactDOM.createRoot(document.getElementById('root') as HTMLElement);
 root.render(
-  <React.StrictMode>
+  <Router>
     <App />
-  </React.StrictMode>
+  </Router>
 );

--- a/yarn.lock
+++ b/yarn.lock
@@ -1035,7 +1035,7 @@
     core-js-pure "^3.20.2"
     regenerator-runtime "^0.13.4"
 
-"@babel/runtime@^7.0.0", "@babel/runtime@^7.10.2", "@babel/runtime@^7.11.2", "@babel/runtime@^7.12.5", "@babel/runtime@^7.16.3", "@babel/runtime@^7.18.9", "@babel/runtime@^7.7.2", "@babel/runtime@^7.8.4", "@babel/runtime@^7.9.2":
+"@babel/runtime@^7.0.0", "@babel/runtime@^7.10.2", "@babel/runtime@^7.11.2", "@babel/runtime@^7.12.5", "@babel/runtime@^7.16.3", "@babel/runtime@^7.18.9", "@babel/runtime@^7.7.2", "@babel/runtime@^7.7.6", "@babel/runtime@^7.8.4", "@babel/runtime@^7.9.2":
   version "7.18.9"
   resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.18.9.tgz#b4fcfce55db3d2e5e080d2490f608a3b9f407f4a"
   integrity sha512-lkqXDcvlFT5rvEjiu6+QYO+1GXrEHRo2LOtS7E4GtX5ESIZOgepqsZBVIj6Pv+a6zqsya9VCgiK1KAK4BvJDAw==
@@ -4832,6 +4832,13 @@ he@^1.2.0:
   resolved "https://registry.yarnpkg.com/he/-/he-1.2.0.tgz#84ae65fa7eafb165fddb61566ae14baf05664f0f"
   integrity sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw==
 
+history@^5.2.0:
+  version "5.3.0"
+  resolved "https://registry.yarnpkg.com/history/-/history-5.3.0.tgz#1548abaa245ba47992f063a0783db91ef201c73b"
+  integrity sha512-ZqaKwjjrAYUYfLG+htGaIIZ4nioX2L70ZUMIFysS3xvBsSG4x/n1V6TXV3N8ZYNuFGlDirFg32T7B6WOUPDYcQ==
+  dependencies:
+    "@babel/runtime" "^7.7.6"
+
 hoist-non-react-statics@^3.0.0, hoist-non-react-statics@^3.3.0:
   version "3.3.2"
   resolved "https://registry.yarnpkg.com/hoist-non-react-statics/-/hoist-non-react-statics-3.3.2.tgz#ece0acaf71d62c2969c2ec59feff42a4b1a85b45"
@@ -7504,6 +7511,21 @@ react-relay@^14.1.0:
     invariant "^2.2.4"
     nullthrows "^1.1.1"
     relay-runtime "14.1.0"
+
+react-router-dom@^6.3.0:
+  version "6.3.0"
+  resolved "https://registry.yarnpkg.com/react-router-dom/-/react-router-dom-6.3.0.tgz#a0216da813454e521905b5fa55e0e5176123f43d"
+  integrity sha512-uaJj7LKytRxZNQV8+RbzJWnJ8K2nPsOOEuX7aQstlMZKQT0164C+X2w6bnkqU3sjtLvpd5ojrezAyfZ1+0sStw==
+  dependencies:
+    history "^5.2.0"
+    react-router "6.3.0"
+
+react-router@6.3.0:
+  version "6.3.0"
+  resolved "https://registry.yarnpkg.com/react-router/-/react-router-6.3.0.tgz#3970cc64b4cb4eae0c1ea5203a80334fdd175557"
+  integrity sha512-7Wh1DzVQ+tlFjkeo+ujvjSqSJmkt1+8JO+T5xklPlgrh70y7ogx75ODRW0ThWhY7S+6yEDks8TYrtQe/aoboBQ==
+  dependencies:
+    history "^5.2.0"
 
 react-scripts@5.0.1:
   version "5.0.1"


### PR DESCRIPTION
## 작업사항

- Search, Result 페이지 및 라우팅 추가
- 페이지네이션 구현 (cursor based, useLazyLoadQuery 이용해서 쿼리)
- 페이지네이션 구현 시 [refetching](https://relay.dev/docs/guided-tour/refetching/refetching-queries-with-different-data/) 방식으로 구현
  - 최초로 ResultQuery를 수행하면 cursor 상태에 endCursor값 저장. 
  - 버튼을 클릭하면 endCursor값을 이용하여 ResultQuery를 다시 수행. cursor상태에 endCursor값 저장.
  - hasNextPage가 false라면 ResultQuery동작버튼을 unmount

## 추가하면 좋은 사항

- 공식문서에 [connection & pagination](https://relay.dev/docs/guided-tour/list-data/connections/)을 이용한 pagination도 있으므로 리팩토링 해볼 것
