### PR TITLE
Fix/1: fix bug when researching after result shown

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -17,11 +17,11 @@ function App() {
   useEffect(() => {
     setQueryArgs((prev) => ({
       options: {
-        fetchKey: (prev?.options.fetchKey ?? 0) + 1,
+        fetchKey: prev?.options.fetchKey ?? 0,
       },
       variables: { endCursor: cursor, searchedWord },
     }));
-  }, [searchedWord]);
+  }, []);
 
   const refetch = useCallback(() => {
     setQueryArgs((prev) => ({
@@ -30,25 +30,24 @@ function App() {
       },
       variables: { endCursor: cursor, searchedWord },
     }));
-  }, [queryArgs.options.fetchKey, cursor]);
+  }, [cursor]);
 
   return (
     <>
       <Routes>
         <Route
           path="/"
-          element={<Search searchedWord={searchedWord} setSearchedWord={setSearchedWord} />}
+          element={
+            <Search
+              searchedWord={searchedWord}
+              setSearchedWord={setSearchedWord}
+              setQueryArgs={setQueryArgs}
+            />
+          }
         />
         <Route
           path="/result/:searchedWord"
-          element={
-            <Result
-              refetch={refetch}
-              queryArgs={queryArgs}
-              setCursor={setCursor}
-              searchedWord={searchedWord}
-            />
-          }
+          element={<Result refetch={refetch} queryArgs={queryArgs} setCursor={setCursor} />}
         />
       </Routes>
     </>

--- a/src/components/Result.tsx
+++ b/src/components/Result.tsx
@@ -7,7 +7,6 @@ function Result({
   refetch,
   queryArgs,
   setCursor,
-  searchedWord,
 }: {
   refetch: any;
   queryArgs: {
@@ -19,7 +18,6 @@ function Result({
     };
   };
   setCursor: Dispatch<SetStateAction<string>>;
-  searchedWord: string;
 }) {
   const [searchedLists, setSearchedLists] = useState<any[]>([]);
   const data: any = useLazyLoadQuery(
@@ -67,7 +65,7 @@ function Result({
         </Fragment>
       ))}
       {data.search.pageInfo.hasNextPage ? (
-        <button onClick={() => refetch()}>더보기</button>
+        <button onClick={() => refetch()}>더 보기</button>
       ) : (
         'End of list'
       )}

--- a/src/components/Search.tsx
+++ b/src/components/Search.tsx
@@ -5,9 +5,11 @@ import { debounce } from 'lodash';
 function Search({
   searchedWord,
   setSearchedWord,
+  setQueryArgs,
 }: {
   searchedWord: string;
   setSearchedWord: Dispatch<SetStateAction<string>>;
+  setQueryArgs: Dispatch<SetStateAction<any>>;
 }) {
   const navigate = useNavigate();
 
@@ -18,13 +20,18 @@ function Search({
 
   const handleSubmit = (e: React.BaseSyntheticEvent) => {
     e.preventDefault();
+    setQueryArgs({
+      options: {
+        fetchKey: 0,
+      },
+      variables: { endCursor: undefined, searchedWord },
+    });
     navigate(`/result/${searchedWord}`);
   };
 
   return (
     <>
       <form onSubmit={handleSubmit}>
-        <div>this is Search component</div>
         <input
           id="input"
           type="text"
@@ -32,7 +39,7 @@ function Search({
           autoComplete="off"
           autoCapitalize="off"
         />
-        <button>to result component</button>
+        <button>Search</button>
       </form>
     </>
   );


### PR DESCRIPTION
## 작업사항

- 버그수정
- 검색 후 결과를 보고 다시 검색하려고 하면 리스트가 처음부터 보여지지 않고 중간부터 보여주는 버그 발생
  - 원인: pagination을 위해 endCursor값을 저장하게 되는데, 새로 검색을 할 때 해당 endcursor값을 사용하여 중간부터 결과가 받아짐
  - 해결: Search 버튼을 누를 때 저장되어 있던 endCursor를 초기화시켜줌
  - 결과: 재검색시에도 정상적으로 첫 번째 결과부터 검색
