### PR TITLE
Feat/4: add repository starred mutation

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -47,7 +47,11 @@ function App() {
         />
         <Route
           path="/result/:searchedWord"
-          element={<Result refetch={refetch} queryArgs={queryArgs} setCursor={setCursor} />}
+          element={
+            <Suspense fallback={'...loading'}>
+              <Result refetch={refetch} queryArgs={queryArgs} setCursor={setCursor} />
+            </Suspense>
+          }
         />
       </Routes>
     </>
@@ -57,9 +61,7 @@ function App() {
 function AppRoot() {
   return (
     <RelayEnvironmentProvider environment={RelayEnvironment}>
-      <Suspense fallback={'Loading...'}>
-        <App />
-      </Suspense>
+      <App />
     </RelayEnvironmentProvider>
   );
 }

--- a/src/components/Search.tsx
+++ b/src/components/Search.tsx
@@ -1,4 +1,4 @@
-import React, { SetStateAction, Dispatch, useState } from 'react';
+import React, { SetStateAction, Dispatch } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { debounce } from 'lodash';
 
@@ -14,9 +14,8 @@ function Search({
   const navigate = useNavigate();
 
   const handleChange = debounce((e: React.BaseSyntheticEvent) => {
-    e.persist();
     setSearchedWord(e.target.value);
-  }, 250);
+  }, 200);
 
   const handleSubmit = (e: React.BaseSyntheticEvent) => {
     e.preventDefault();

--- a/src/components/__generated__/ResultAddStarMutation.graphql.ts
+++ b/src/components/__generated__/ResultAddStarMutation.graphql.ts
@@ -1,0 +1,160 @@
+/**
+ * @generated SignedSource<<fa189fdd09d9ab7b976ebfdf7514eb52>>
+ * @lightSyntaxTransform
+ * @nogrep
+ */
+
+/* tslint:disable */
+/* eslint-disable */
+// @ts-nocheck
+
+import { ConcreteRequest, Mutation } from 'relay-runtime';
+export type ResultAddStarMutation$variables = {
+  starrableId: string;
+};
+export type ResultAddStarMutation$data = {
+  readonly addStar: {
+    readonly starrable: {
+      readonly id: string;
+      readonly stargazerCount: number;
+      readonly viewerHasStarred: boolean;
+    } | null;
+  } | null;
+};
+export type ResultAddStarMutation = {
+  response: ResultAddStarMutation$data;
+  variables: ResultAddStarMutation$variables;
+};
+
+const node: ConcreteRequest = (function(){
+var v0 = [
+  {
+    "defaultValue": null,
+    "kind": "LocalArgument",
+    "name": "starrableId"
+  }
+],
+v1 = [
+  {
+    "fields": [
+      {
+        "kind": "Variable",
+        "name": "starrableId",
+        "variableName": "starrableId"
+      }
+    ],
+    "kind": "ObjectValue",
+    "name": "input"
+  }
+],
+v2 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "id",
+  "storageKey": null
+},
+v3 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "stargazerCount",
+  "storageKey": null
+},
+v4 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "viewerHasStarred",
+  "storageKey": null
+};
+return {
+  "fragment": {
+    "argumentDefinitions": (v0/*: any*/),
+    "kind": "Fragment",
+    "metadata": null,
+    "name": "ResultAddStarMutation",
+    "selections": [
+      {
+        "alias": null,
+        "args": (v1/*: any*/),
+        "concreteType": "AddStarPayload",
+        "kind": "LinkedField",
+        "name": "addStar",
+        "plural": false,
+        "selections": [
+          {
+            "alias": null,
+            "args": null,
+            "concreteType": null,
+            "kind": "LinkedField",
+            "name": "starrable",
+            "plural": false,
+            "selections": [
+              (v2/*: any*/),
+              (v3/*: any*/),
+              (v4/*: any*/)
+            ],
+            "storageKey": null
+          }
+        ],
+        "storageKey": null
+      }
+    ],
+    "type": "Mutation",
+    "abstractKey": null
+  },
+  "kind": "Request",
+  "operation": {
+    "argumentDefinitions": (v0/*: any*/),
+    "kind": "Operation",
+    "name": "ResultAddStarMutation",
+    "selections": [
+      {
+        "alias": null,
+        "args": (v1/*: any*/),
+        "concreteType": "AddStarPayload",
+        "kind": "LinkedField",
+        "name": "addStar",
+        "plural": false,
+        "selections": [
+          {
+            "alias": null,
+            "args": null,
+            "concreteType": null,
+            "kind": "LinkedField",
+            "name": "starrable",
+            "plural": false,
+            "selections": [
+              {
+                "alias": null,
+                "args": null,
+                "kind": "ScalarField",
+                "name": "__typename",
+                "storageKey": null
+              },
+              (v2/*: any*/),
+              (v3/*: any*/),
+              (v4/*: any*/)
+            ],
+            "storageKey": null
+          }
+        ],
+        "storageKey": null
+      }
+    ]
+  },
+  "params": {
+    "cacheID": "b7a842e4090a623e6cacac2cec3be0ca",
+    "id": null,
+    "metadata": {},
+    "name": "ResultAddStarMutation",
+    "operationKind": "mutation",
+    "text": "mutation ResultAddStarMutation(\n  $starrableId: ID!\n) {\n  addStar(input: {starrableId: $starrableId}) {\n    starrable {\n      __typename\n      id\n      stargazerCount\n      ... on Repository {\n        id\n      }\n      viewerHasStarred\n    }\n  }\n}\n"
+  }
+};
+})();
+
+(node as any).hash = "074aebdff024a17fe78c09d0e43a3b3e";
+
+export default node;

--- a/src/components/__generated__/ResultQuery.graphql.ts
+++ b/src/components/__generated__/ResultQuery.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<62fdbfca83d40e10c6cfc6b116156f2b>>
+ * @generated SignedSource<<6f35bba117efab1afb9f884e5b4da3f7>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -22,6 +22,7 @@ export type ResultQuery$data = {
         readonly id?: string;
         readonly name?: string;
         readonly stargazerCount?: number;
+        readonly viewerHasStarred?: boolean;
       } | null;
     } | null> | null;
     readonly pageInfo: {
@@ -108,6 +109,13 @@ v4 = {
       "args": null,
       "kind": "ScalarField",
       "name": "stargazerCount",
+      "storageKey": null
+    },
+    {
+      "alias": null,
+      "args": null,
+      "kind": "ScalarField",
+      "name": "viewerHasStarred",
       "storageKey": null
     }
   ],
@@ -255,16 +263,16 @@ return {
     ]
   },
   "params": {
-    "cacheID": "3876b6718fd724f03415dbea1af8c3d0",
+    "cacheID": "f9e3abe08171240f812e82f93d0c1ce0",
     "id": null,
     "metadata": {},
     "name": "ResultQuery",
     "operationKind": "query",
-    "text": "query ResultQuery(\n  $endCursor: String\n  $searchedWord: String!\n) {\n  search(query: $searchedWord, first: 5, after: $endCursor, type: REPOSITORY) {\n    repositoryCount\n    edges {\n      node {\n        __typename\n        ... on Repository {\n          id\n          name\n          description\n          stargazerCount\n        }\n        ... on Node {\n          __isNode: __typename\n          id\n        }\n      }\n      cursor\n    }\n    pageInfo {\n      endCursor\n      hasNextPage\n    }\n  }\n}\n"
+    "text": "query ResultQuery(\n  $endCursor: String\n  $searchedWord: String!\n) {\n  search(query: $searchedWord, first: 5, after: $endCursor, type: REPOSITORY) {\n    repositoryCount\n    edges {\n      node {\n        __typename\n        ... on Repository {\n          id\n          name\n          description\n          stargazerCount\n          viewerHasStarred\n        }\n        ... on Node {\n          __isNode: __typename\n          id\n        }\n      }\n      cursor\n    }\n    pageInfo {\n      endCursor\n      hasNextPage\n    }\n  }\n}\n"
   }
 };
 })();
 
-(node as any).hash = "1efe5209def9e549964f7df4e0bae1c5";
+(node as any).hash = "6efd121d3cd3a5c9cb9fc2fc5b3c6617";
 
 export default node;

--- a/src/components/__generated__/ResultRemoveStarMutation.graphql.ts
+++ b/src/components/__generated__/ResultRemoveStarMutation.graphql.ts
@@ -1,0 +1,160 @@
+/**
+ * @generated SignedSource<<4decc2a9a671cb8a787029741494a931>>
+ * @lightSyntaxTransform
+ * @nogrep
+ */
+
+/* tslint:disable */
+/* eslint-disable */
+// @ts-nocheck
+
+import { ConcreteRequest, Mutation } from 'relay-runtime';
+export type ResultRemoveStarMutation$variables = {
+  starrableId: string;
+};
+export type ResultRemoveStarMutation$data = {
+  readonly removeStar: {
+    readonly starrable: {
+      readonly id: string;
+      readonly stargazerCount: number;
+      readonly viewerHasStarred: boolean;
+    } | null;
+  } | null;
+};
+export type ResultRemoveStarMutation = {
+  response: ResultRemoveStarMutation$data;
+  variables: ResultRemoveStarMutation$variables;
+};
+
+const node: ConcreteRequest = (function(){
+var v0 = [
+  {
+    "defaultValue": null,
+    "kind": "LocalArgument",
+    "name": "starrableId"
+  }
+],
+v1 = [
+  {
+    "fields": [
+      {
+        "kind": "Variable",
+        "name": "starrableId",
+        "variableName": "starrableId"
+      }
+    ],
+    "kind": "ObjectValue",
+    "name": "input"
+  }
+],
+v2 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "id",
+  "storageKey": null
+},
+v3 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "stargazerCount",
+  "storageKey": null
+},
+v4 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "viewerHasStarred",
+  "storageKey": null
+};
+return {
+  "fragment": {
+    "argumentDefinitions": (v0/*: any*/),
+    "kind": "Fragment",
+    "metadata": null,
+    "name": "ResultRemoveStarMutation",
+    "selections": [
+      {
+        "alias": null,
+        "args": (v1/*: any*/),
+        "concreteType": "RemoveStarPayload",
+        "kind": "LinkedField",
+        "name": "removeStar",
+        "plural": false,
+        "selections": [
+          {
+            "alias": null,
+            "args": null,
+            "concreteType": null,
+            "kind": "LinkedField",
+            "name": "starrable",
+            "plural": false,
+            "selections": [
+              (v2/*: any*/),
+              (v3/*: any*/),
+              (v4/*: any*/)
+            ],
+            "storageKey": null
+          }
+        ],
+        "storageKey": null
+      }
+    ],
+    "type": "Mutation",
+    "abstractKey": null
+  },
+  "kind": "Request",
+  "operation": {
+    "argumentDefinitions": (v0/*: any*/),
+    "kind": "Operation",
+    "name": "ResultRemoveStarMutation",
+    "selections": [
+      {
+        "alias": null,
+        "args": (v1/*: any*/),
+        "concreteType": "RemoveStarPayload",
+        "kind": "LinkedField",
+        "name": "removeStar",
+        "plural": false,
+        "selections": [
+          {
+            "alias": null,
+            "args": null,
+            "concreteType": null,
+            "kind": "LinkedField",
+            "name": "starrable",
+            "plural": false,
+            "selections": [
+              {
+                "alias": null,
+                "args": null,
+                "kind": "ScalarField",
+                "name": "__typename",
+                "storageKey": null
+              },
+              (v2/*: any*/),
+              (v3/*: any*/),
+              (v4/*: any*/)
+            ],
+            "storageKey": null
+          }
+        ],
+        "storageKey": null
+      }
+    ]
+  },
+  "params": {
+    "cacheID": "a3fea0b449c206147e52d445b1640a91",
+    "id": null,
+    "metadata": {},
+    "name": "ResultRemoveStarMutation",
+    "operationKind": "mutation",
+    "text": "mutation ResultRemoveStarMutation(\n  $starrableId: ID!\n) {\n  removeStar(input: {starrableId: $starrableId}) {\n    starrable {\n      __typename\n      id\n      stargazerCount\n      viewerHasStarred\n    }\n  }\n}\n"
+  }
+};
+})();
+
+(node as any).hash = "81a574a9b8c664a63808d5b00be71635";
+
+export default node;


### PR DESCRIPTION
## 작업사항

- Mutation을 이용한 repository star 등록과 삭제 구현
- 구현 과정
1. 처음 생각
    1. 현재 사용자의 name을 이용해서 starred한 목록을 불러온다.
    2. starred 목록과 ResultQuery를 비교해서 starred된 레포지토리는 toggle on 시킨다.
    3. 버튼을 클릭하면 starred목록을 직접 조작해서 star목록을 직접 넣거나 제거한다.
    4. 처음 생각대로 한다면 필요 없는 query가 늘어나고 가독성이 떨어질 것이다.
2. 두 번째 생각
    1. 현재 사용자의 정보를 가져올 수 있는 정보가 있나 찾다 viewer 쿼리를 이용하면 현재 사용자의 정보를 가져올 수 있다는 것을 알았다.
    2. viewer쿼리에서 사용자가 starred 한 목록을 가져와서 1번의 b, c반복
    3. 처음 생각보다는 쿼리가 줄어들지만 마찬가지로 복잡해진다.
3. 세 번째 생각
    1. API 목록을 보니 viewerHasStarred 라는 필드가 있었다. 해당 필드를 보자마자 뭔가 느낌이 와서 ResultQuery에 필드를 입력 후 결과를 보니 현재 사용자(Viewer)가 starred하면 true, 아니면 false가 나왔다.
    2. 이를 이용해서 구현!

- 기존의 리스트를 누적해서 보여주면서 star Mutation은 우선 실패
  - 더 보기 버튼을 누를 때마다 전체 화면이 suspense가 일어나면서 좋지 않은 사용자 경험이 나온다
  - 레포지토리 스타 숫자를 누를때 Mutaion이 실행되는데, 기존에는 내가 만든 배열상태에 useLazyLoadQuery의 결과값인 data를 저장해놓고 해당 배열을 map으로 렌더링 시켰다. 따라서  서버의 변경사항이 즉각적으로 렌더링되지 않았다.
  - 해결방법 → useLazyLoadQuery를 사용하면 data가 리턴값으로 나오는데, Mutation을 수행할 시 바뀐 값을 자동으로 서버에서 가져오고(구독 중) 최신 정보로 리렌더링.
