### PR TITLE
Refactor/2: refactored using usePaginationFragment

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -11,43 +11,14 @@ import { Oval } from 'react-loader-spinner';
 import theme from './style/theme';
 
 function App() {
-  const [cursor, setCursor] = useState<any>(undefined);
   const [searchedWord, setSearchedWord] = useState<string>('');
-  const [queryArgs, setQueryArgs] = useState({
-    options: { fetchKey: 0 },
-    variables: { endCursor: cursor, searchedWord },
-  });
-
-  useEffect(() => {
-    setQueryArgs((prev) => ({
-      options: {
-        fetchKey: prev?.options.fetchKey ?? 0,
-      },
-      variables: { endCursor: cursor, searchedWord },
-    }));
-  }, []);
-
-  const refetch = useCallback(() => {
-    setQueryArgs((prev) => ({
-      options: {
-        fetchKey: (prev?.options.fetchKey ?? 0) + 1,
-      },
-      variables: { endCursor: cursor, searchedWord },
-    }));
-  }, [cursor]);
 
   return (
     <>
       <Routes>
         <Route
           path="/"
-          element={
-            <Search
-              searchedWord={searchedWord}
-              setSearchedWord={setSearchedWord}
-              setQueryArgs={setQueryArgs}
-            />
-          }
+          element={<Search searchedWord={searchedWord} setSearchedWord={setSearchedWord} />}
         />
         <Route
           path="/result/:searchedWord"
@@ -56,8 +27,8 @@ function App() {
               fallback={
                 <LoaderWrapper>
                   <Oval
-                    height={60}
-                    width={60}
+                    height={70}
+                    width={70}
                     color="#3cb46e"
                     visible={true}
                     ariaLabel="oval-loading"
@@ -68,7 +39,7 @@ function App() {
                 </LoaderWrapper>
               }
             >
-              <Result refetch={refetch} queryArgs={queryArgs} setCursor={setCursor} />
+              <Result searchedWord={searchedWord} />
             </Suspense>
           }
         />

--- a/src/components/Search.tsx
+++ b/src/components/Search.tsx
@@ -7,26 +7,18 @@ import githubImage from './assets/github_graphql.png';
 function Search({
   searchedWord,
   setSearchedWord,
-  setQueryArgs,
 }: {
   searchedWord: string;
   setSearchedWord: Dispatch<SetStateAction<string>>;
-  setQueryArgs: Dispatch<SetStateAction<any>>;
 }) {
   const navigate = useNavigate();
 
   const handleChange = debounce((e: React.BaseSyntheticEvent) => {
     setSearchedWord(e.target.value);
-  }, 100);
+  }, 200);
 
   const handleSubmit = (e: React.BaseSyntheticEvent) => {
     e.preventDefault();
-    setQueryArgs({
-      options: {
-        fetchKey: 0,
-      },
-      variables: { endCursor: undefined, searchedWord },
-    });
     navigate(`/result/${searchedWord}`);
   };
 
@@ -76,6 +68,10 @@ const SearchInput = styled.input`
   width: 15rem;
   padding: 0.7rem;
   font-size: 1rem;
+  &:focus {
+    border-color: ${({ theme }) => theme.colors.green};
+    outline: none;
+  }
 `;
 
 const Button = styled.button`

--- a/src/components/__generated__/ResultPaginationQuery.graphql.ts
+++ b/src/components/__generated__/ResultPaginationQuery.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<8a793c9a1fbcdc1ce74d263e76d2a991>>
+ * @generated SignedSource<<dddb504a93fdd1b6ef52ba4b9efc796e>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -10,15 +10,17 @@
 
 import { ConcreteRequest, Query } from 'relay-runtime';
 import { FragmentRefs } from "relay-runtime";
-export type ResultQuery$variables = {
+export type ResultPaginationQuery$variables = {
+  after?: string | null;
+  first?: number | null;
   searchedWord: string;
 };
-export type ResultQuery$data = {
+export type ResultPaginationQuery$data = {
   readonly " $fragmentSpreads": FragmentRefs<"Result_result">;
 };
-export type ResultQuery = {
-  response: ResultQuery$data;
-  variables: ResultQuery$variables;
+export type ResultPaginationQuery = {
+  response: ResultPaginationQuery$data;
+  variables: ResultPaginationQuery$variables;
 };
 
 const node: ConcreteRequest = (function(){
@@ -26,15 +28,32 @@ var v0 = [
   {
     "defaultValue": null,
     "kind": "LocalArgument",
+    "name": "after"
+  },
+  {
+    "defaultValue": 5,
+    "kind": "LocalArgument",
+    "name": "first"
+  },
+  {
+    "defaultValue": null,
+    "kind": "LocalArgument",
     "name": "searchedWord"
   }
 ],
-v1 = [
-  {
-    "kind": "Literal",
-    "name": "first",
-    "value": 5
-  },
+v1 = {
+  "kind": "Variable",
+  "name": "after",
+  "variableName": "after"
+},
+v2 = {
+  "kind": "Variable",
+  "name": "first",
+  "variableName": "first"
+},
+v3 = [
+  (v1/*: any*/),
+  (v2/*: any*/),
   {
     "kind": "Variable",
     "name": "query",
@@ -46,7 +65,7 @@ v1 = [
     "value": "REPOSITORY"
   }
 ],
-v2 = {
+v4 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
@@ -58,10 +77,12 @@ return {
     "argumentDefinitions": (v0/*: any*/),
     "kind": "Fragment",
     "metadata": null,
-    "name": "ResultQuery",
+    "name": "ResultPaginationQuery",
     "selections": [
       {
         "args": [
+          (v1/*: any*/),
+          (v2/*: any*/),
           {
             "kind": "Variable",
             "name": "searchedWord",
@@ -79,11 +100,11 @@ return {
   "operation": {
     "argumentDefinitions": (v0/*: any*/),
     "kind": "Operation",
-    "name": "ResultQuery",
+    "name": "ResultPaginationQuery",
     "selections": [
       {
         "alias": null,
-        "args": (v1/*: any*/),
+        "args": (v3/*: any*/),
         "concreteType": "SearchResultItemConnection",
         "kind": "LinkedField",
         "name": "search",
@@ -122,7 +143,7 @@ return {
                   {
                     "kind": "InlineFragment",
                     "selections": [
-                      (v2/*: any*/),
+                      (v4/*: any*/),
                       {
                         "alias": null,
                         "args": null,
@@ -158,7 +179,7 @@ return {
                   {
                     "kind": "InlineFragment",
                     "selections": [
-                      (v2/*: any*/)
+                      (v4/*: any*/)
                     ],
                     "type": "Node",
                     "abstractKey": "__isNode"
@@ -206,7 +227,7 @@ return {
       },
       {
         "alias": null,
-        "args": (v1/*: any*/),
+        "args": (v3/*: any*/),
         "filters": [
           "query",
           "type"
@@ -219,16 +240,16 @@ return {
     ]
   },
   "params": {
-    "cacheID": "702b64bc6dfdfc0e16d5e4a87f93a28e",
+    "cacheID": "41aadb537d00c4feb50aaeac1983bf6c",
     "id": null,
     "metadata": {},
-    "name": "ResultQuery",
+    "name": "ResultPaginationQuery",
     "operationKind": "query",
-    "text": "query ResultQuery(\n  $searchedWord: String!\n) {\n  ...Result_result_orFA\n}\n\nfragment Result_result_orFA on Query {\n  search(query: $searchedWord, first: 5, type: REPOSITORY) {\n    repositoryCount\n    edges {\n      node {\n        __typename\n        ... on Repository {\n          id\n          name\n          description\n          stargazerCount\n          viewerHasStarred\n        }\n        ... on Node {\n          __isNode: __typename\n          id\n        }\n      }\n      cursor\n    }\n    pageInfo {\n      endCursor\n      hasNextPage\n    }\n  }\n}\n"
+    "text": "query ResultPaginationQuery(\n  $after: String\n  $first: Int = 5\n  $searchedWord: String!\n) {\n  ...Result_result_1rkBg0\n}\n\nfragment Result_result_1rkBg0 on Query {\n  search(query: $searchedWord, first: $first, after: $after, type: REPOSITORY) {\n    repositoryCount\n    edges {\n      node {\n        __typename\n        ... on Repository {\n          id\n          name\n          description\n          stargazerCount\n          viewerHasStarred\n        }\n        ... on Node {\n          __isNode: __typename\n          id\n        }\n      }\n      cursor\n    }\n    pageInfo {\n      endCursor\n      hasNextPage\n    }\n  }\n}\n"
   }
 };
 })();
 
-(node as any).hash = "a509d7edd4ec3f535bbcc2d8be73a4ea";
+(node as any).hash = "47e0ff873adcb28e9ae464c3a9fa7198";
 
 export default node;

--- a/src/components/__generated__/Result_result.graphql.ts
+++ b/src/components/__generated__/Result_result.graphql.ts
@@ -1,0 +1,225 @@
+/**
+ * @generated SignedSource<<b2e814e018eb677c3f6677a0a7d73c24>>
+ * @lightSyntaxTransform
+ * @nogrep
+ */
+
+/* tslint:disable */
+/* eslint-disable */
+// @ts-nocheck
+
+import { ReaderFragment, RefetchableFragment } from 'relay-runtime';
+import { FragmentRefs } from "relay-runtime";
+export type Result_result$data = {
+  readonly search: {
+    readonly edges: ReadonlyArray<{
+      readonly cursor: string;
+      readonly node: {
+        readonly description?: string | null;
+        readonly id?: string;
+        readonly name?: string;
+        readonly stargazerCount?: number;
+        readonly viewerHasStarred?: boolean;
+      } | null;
+    } | null> | null;
+    readonly pageInfo: {
+      readonly endCursor: string | null;
+      readonly hasNextPage: boolean;
+    };
+    readonly repositoryCount: number;
+  };
+  readonly " $fragmentType": "Result_result";
+};
+export type Result_result$key = {
+  readonly " $data"?: Result_result$data;
+  readonly " $fragmentSpreads": FragmentRefs<"Result_result">;
+};
+
+const node: ReaderFragment = (function(){
+var v0 = [
+  "search"
+];
+return {
+  "argumentDefinitions": [
+    {
+      "defaultValue": null,
+      "kind": "LocalArgument",
+      "name": "after"
+    },
+    {
+      "defaultValue": 5,
+      "kind": "LocalArgument",
+      "name": "first"
+    },
+    {
+      "defaultValue": null,
+      "kind": "LocalArgument",
+      "name": "searchedWord"
+    }
+  ],
+  "kind": "Fragment",
+  "metadata": {
+    "connection": [
+      {
+        "count": "first",
+        "cursor": "after",
+        "direction": "forward",
+        "path": (v0/*: any*/)
+      }
+    ],
+    "refetch": {
+      "connection": {
+        "forward": {
+          "count": "first",
+          "cursor": "after"
+        },
+        "backward": null,
+        "path": (v0/*: any*/)
+      },
+      "fragmentPathInResult": [],
+      "operation": require('./ResultPaginationQuery.graphql')
+    }
+  },
+  "name": "Result_result",
+  "selections": [
+    {
+      "alias": "search",
+      "args": [
+        {
+          "kind": "Variable",
+          "name": "query",
+          "variableName": "searchedWord"
+        },
+        {
+          "kind": "Literal",
+          "name": "type",
+          "value": "REPOSITORY"
+        }
+      ],
+      "concreteType": "SearchResultItemConnection",
+      "kind": "LinkedField",
+      "name": "__Repository_search_connection",
+      "plural": false,
+      "selections": [
+        {
+          "alias": null,
+          "args": null,
+          "kind": "ScalarField",
+          "name": "repositoryCount",
+          "storageKey": null
+        },
+        {
+          "alias": null,
+          "args": null,
+          "concreteType": "SearchResultItemEdge",
+          "kind": "LinkedField",
+          "name": "edges",
+          "plural": true,
+          "selections": [
+            {
+              "alias": null,
+              "args": null,
+              "concreteType": null,
+              "kind": "LinkedField",
+              "name": "node",
+              "plural": false,
+              "selections": [
+                {
+                  "kind": "InlineFragment",
+                  "selections": [
+                    {
+                      "alias": null,
+                      "args": null,
+                      "kind": "ScalarField",
+                      "name": "id",
+                      "storageKey": null
+                    },
+                    {
+                      "alias": null,
+                      "args": null,
+                      "kind": "ScalarField",
+                      "name": "name",
+                      "storageKey": null
+                    },
+                    {
+                      "alias": null,
+                      "args": null,
+                      "kind": "ScalarField",
+                      "name": "description",
+                      "storageKey": null
+                    },
+                    {
+                      "alias": null,
+                      "args": null,
+                      "kind": "ScalarField",
+                      "name": "stargazerCount",
+                      "storageKey": null
+                    },
+                    {
+                      "alias": null,
+                      "args": null,
+                      "kind": "ScalarField",
+                      "name": "viewerHasStarred",
+                      "storageKey": null
+                    }
+                  ],
+                  "type": "Repository",
+                  "abstractKey": null
+                },
+                {
+                  "alias": null,
+                  "args": null,
+                  "kind": "ScalarField",
+                  "name": "__typename",
+                  "storageKey": null
+                }
+              ],
+              "storageKey": null
+            },
+            {
+              "alias": null,
+              "args": null,
+              "kind": "ScalarField",
+              "name": "cursor",
+              "storageKey": null
+            }
+          ],
+          "storageKey": null
+        },
+        {
+          "alias": null,
+          "args": null,
+          "concreteType": "PageInfo",
+          "kind": "LinkedField",
+          "name": "pageInfo",
+          "plural": false,
+          "selections": [
+            {
+              "alias": null,
+              "args": null,
+              "kind": "ScalarField",
+              "name": "endCursor",
+              "storageKey": null
+            },
+            {
+              "alias": null,
+              "args": null,
+              "kind": "ScalarField",
+              "name": "hasNextPage",
+              "storageKey": null
+            }
+          ],
+          "storageKey": null
+        }
+      ],
+      "storageKey": null
+    }
+  ],
+  "type": "Query",
+  "abstractKey": null
+};
+})();
+
+(node as any).hash = "47e0ff873adcb28e9ae464c3a9fa7198";
+
+export default node;


### PR DESCRIPTION
## 작업사항

- 기존 useLazyLoadQuery 만을 사용하여 구현한 cursor based pagination을 usePaginationFragment 사용으로 변경
- 기존의 방법은 pagination을 구현하기 위해 많은 useEffect, 상태들이 있었지만 usePaginationFragment를 사용함으로써 useEffect와 state 및 props가 대폭 감소
- fragment를 이용하여 필요한 정보만을 refetch
