### PR TITLE
Fix/3: fixed double request when typed fast

### DIFF
--- a/src/components/Search.tsx
+++ b/src/components/Search.tsx
@@ -1,7 +1,6 @@
-import React, { SetStateAction, Dispatch } from 'react';
+import React, { SetStateAction, Dispatch, useDeferredValue, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 import styled from 'styled-components';
-import { debounce } from 'lodash';
 import githubImage from './assets/github_graphql.png';
 
 function Search({
@@ -12,14 +11,17 @@ function Search({
   setSearchedWord: Dispatch<SetStateAction<string>>;
 }) {
   const navigate = useNavigate();
+  const [input, setInput] = useState('');
+  const deferredSearchedWord = useDeferredValue(input);
 
-  const handleChange = debounce((e: React.BaseSyntheticEvent) => {
-    setSearchedWord(e.target.value);
-  }, 200);
+  const handleChange = (e: React.BaseSyntheticEvent) => {
+    setInput(e.target.value);
+  };
 
   const handleSubmit = (e: React.BaseSyntheticEvent) => {
     e.preventDefault();
-    navigate(`/result/${searchedWord}`);
+    setSearchedWord(deferredSearchedWord);
+    navigate(`/result/${input}`);
   };
 
   return (
@@ -37,7 +39,7 @@ function Search({
               autoCapitalize="off"
             />
           </InputWrapper>
-          <Button disabled={!searchedWord.length}>Search</Button>
+          <Button disabled={!input.length}>Search</Button>
         </SearchForm>
       </Container>
     </>


### PR DESCRIPTION
## 작업사항

- input에 값 입력 후 빠른 시간안에 엔터를 누르면 요청이 두 번 발생하는 현상 해결
- 원인: debounce를 사용함으로써 빠르게 엔터를 누르게 되면 이전 debounce callback이 실행되면서 두 번 요청됨
- 해결: useDeferredValue 훅을 사용함으로써 해결
- 결과: input 입력 시 렌더링 감소, 버그 해결, 코드 간소화
